### PR TITLE
Fix sed expression in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           tag="${{ steps.vars.outputs.tag }}"
           sed -i -E "s/^(\s*\* Version:\s*).*/\1${tag}/" printed-product-customizer.php
-          sed -i -E "s/(define\('FPC_VERSION', ')[^']+(');)/\1${tag}\2/" printed-product-customizer.php
+          sed -i -E "s/(define\('FPC_VERSION', ')[^']+('\);)/\1${tag}\2/" printed-product-customizer.php
 
       - name: Commit updated version
         run: |


### PR DESCRIPTION
## Summary
- fix sed command in release workflow to handle literal parenthesis when updating FPC_VERSION

## Testing
- `php -l printed-product-customizer.php`
- `yamllint .github/workflows/release.yml` *(fails: command not found; attempted `apt-get update` but encountered 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893c9c96ec8833290b716f9d5420d28