### PR TITLE
Allow Google Sheet URL in admin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Initial scaffold for a WordPress/WooCommerce plugin that enables configuration o
 ## Google Sheets Sync
 
 1. Navigate to **WooCommerce → Filament Inventory** in the WordPress admin.
-2. Enter your Google API key, sheet ID, and range (or tab name) and save settings.
+2. Enter your Google API key and full Google Sheet URL (e.g. `https://docs.google.com/spreadsheets/d/XYZ/edit#gid=123`) and save settings. The plugin will automatically extract the sheet and tab information.
 3. Click **Sync Now** to fetch filament data.
 4. The sheet must have a header row with columns: `slug`, `material`, `price_per_kg`, `stock_grams`, `color`, `texture`.
 


### PR DESCRIPTION
## Summary
- add helper methods to parse Google Sheet URLs and look up tab names
- accept a single Sheet URL in settings and automatically store sheet and tab
- update README to reflect simplified Google Sheets configuration

## Testing
- `php -l admin/menu-filament.php`
- `php -l includes/class-filament-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_6893d520d0908332a5ebcb4693d3200a