### PR TITLE
Add SVG logo management with sanitization

### DIFF
--- a/admin/menu-logos.php
+++ b/admin/menu-logos.php
@@ -1,0 +1,92 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Register submenu for predefined logos
+add_action('admin_menu', 'fpc_register_logo_menu');
+function fpc_register_logo_menu() {
+    add_submenu_page(
+        'woocommerce',
+        __('Predefined Logos', 'printed-product-customizer'),
+        __('Predefined Logos', 'printed-product-customizer'),
+        'manage_woocommerce',
+        'fpc_predefined_logos',
+        'fpc_render_logo_page'
+    );
+}
+
+function fpc_render_logo_page() {
+    if (!current_user_can('manage_woocommerce')) {
+        return;
+    }
+
+    if (isset($_POST['fpc_upload_logo']) && check_admin_referer('fpc_upload_logo')) {
+        if (!empty($_FILES['fpc_logo_file']['tmp_name'])) {
+            $raw = file_get_contents($_FILES['fpc_logo_file']['tmp_name']);
+            $sanitized = FPC_SVG_Logo::sanitize_svg($raw);
+            $layers = FPC_SVG_Logo::parse_svg_layers($sanitized);
+
+            $label = sanitize_text_field($_POST['fpc_logo_label'] ?? '');
+            $price = floatval($_POST['fpc_logo_price'] ?? 0);
+            $slug  = sanitize_title(pathinfo($_FILES['fpc_logo_file']['name'], PATHINFO_FILENAME));
+
+            $upload_dir = wp_upload_dir();
+            $dir = trailingslashit($upload_dir['basedir']) . 'fpc-logos';
+            if (!file_exists($dir)) {
+                wp_mkdir_p($dir);
+            }
+            $file_path = trailingslashit($dir) . $slug . '.svg';
+            file_put_contents($file_path, $sanitized);
+
+            $logos = get_option('fpc_predefined_logos', []);
+            $logos[$slug] = [
+                'label'           => $label ?: $slug,
+                'priceAdjustment' => $price,
+                'layers'          => $layers,
+            ];
+            update_option('fpc_predefined_logos', $logos);
+
+            echo '<div class="updated"><p>' . esc_html__('Logo uploaded.', 'printed-product-customizer') . '</p></div>';
+        }
+    }
+
+    $logos = get_option('fpc_predefined_logos', []);
+
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html__('Predefined Logos', 'printed-product-customizer') . '</h1>';
+
+    echo '<form method="post" enctype="multipart/form-data" style="margin-bottom:20px;">';
+    wp_nonce_field('fpc_upload_logo');
+    echo '<table class="form-table"><tbody>';
+    echo '<tr><th><label for="fpc_logo_label">' . esc_html__('Label', 'printed-product-customizer') . '</label></th>';
+    echo '<td><input type="text" id="fpc_logo_label" name="fpc_logo_label" class="regular-text" /></td></tr>';
+    echo '<tr><th><label for="fpc_logo_file">' . esc_html__('SVG File', 'printed-product-customizer') . '</label></th>';
+    echo '<td><input type="file" id="fpc_logo_file" name="fpc_logo_file" accept=".svg" /></td></tr>';
+    echo '<tr><th><label for="fpc_logo_price">' . esc_html__('Price Adjustment', 'printed-product-customizer') . '</label></th>';
+    echo '<td><input type="number" step="any" id="fpc_logo_price" name="fpc_logo_price" /></td></tr>';
+    echo '</tbody></table>';
+    echo '<p><input type="submit" name="fpc_upload_logo" class="button button-primary" value="' . esc_attr__('Upload', 'printed-product-customizer') . '" /></p>';
+    echo '</form>';
+
+    if (!empty($logos)) {
+        echo '<table class="widefat"><thead><tr>';
+        echo '<th>' . esc_html__('Slug', 'printed-product-customizer') . '</th>';
+        echo '<th>' . esc_html__('Label', 'printed-product-customizer') . '</th>';
+        echo '<th>' . esc_html__('Layers', 'printed-product-customizer') . '</th>';
+        echo '<th>' . esc_html__('Price Adj.', 'printed-product-customizer') . '</th>';
+        echo '</tr></thead><tbody>';
+        foreach ($logos as $slug => $data) {
+            $count = count($data['layers']);
+            echo '<tr>';
+            echo '<td>' . esc_html($slug) . '</td>';
+            echo '<td>' . esc_html($data['label'] ?? '') . '</td>';
+            echo '<td>' . esc_html($count) . '</td>';
+            echo '<td>' . esc_html($data['priceAdjustment'] ?? 0) . '</td>';
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
+    }
+
+    echo '</div>';
+}

--- a/includes/class-svg-logo.php
+++ b/includes/class-svg-logo.php
@@ -1,0 +1,101 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class FPC_SVG_Logo {
+    /**
+     * Sanitize SVG content by stripping disallowed elements and attributes.
+     */
+    public static function sanitize_svg($svg_content) {
+        if (empty($svg_content)) {
+            return '';
+        }
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadXML($svg_content, LIBXML_NONET);
+        libxml_clear_errors();
+
+        $xpath = new DOMXPath($dom);
+        $disallowed = ['script', 'foreignObject', 'iframe', 'embed', 'object', 'image', 'style', 'metadata'];
+        foreach ($disallowed as $tag) {
+            foreach ($xpath->query('//' . $tag) as $el) {
+                $el->parentNode->removeChild($el);
+            }
+        }
+
+        $allowed_tags  = ['svg', 'g', 'path', 'use'];
+        $allowed_attrs = ['id', 'class', 'd', 'fill', 'viewBox', 'xmlns', 'width', 'height', 'x', 'y', 'xlink:href'];
+
+        $all = $dom->getElementsByTagName('*');
+        for ($i = $all->length - 1; $i >= 0; $i--) {
+            $el = $all->item($i);
+            if (!in_array($el->nodeName, $allowed_tags, true)) {
+                $el->parentNode->removeChild($el);
+                continue;
+            }
+            if ($el->hasAttributes()) {
+                $remove_attrs = [];
+                foreach ($el->attributes as $attr) {
+                    $name = $attr->nodeName;
+                    if (stripos($name, 'on') === 0 || !in_array($name, $allowed_attrs, true)) {
+                        $remove_attrs[] = $name;
+                    }
+                }
+                foreach ($remove_attrs as $ra) {
+                    $el->removeAttribute($ra);
+                }
+            }
+        }
+
+        return $dom->saveXML();
+    }
+
+    /**
+     * Parse SVG into layer definitions keyed by id or fill color.
+     */
+    public static function parse_svg_layers($svg_content) {
+        $layers = [];
+        if (empty($svg_content)) {
+            return $layers;
+        }
+        $dom = new DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadXML($svg_content, LIBXML_NONET);
+        libxml_clear_errors();
+
+        $xpath = new DOMXPath($dom);
+        $index = 1;
+        foreach ($xpath->query('//*[local-name()="g" or local-name()="path"]') as $node) {
+            $id = $node->getAttribute('id');
+            if (!$id) {
+                $fill = $node->getAttribute('fill');
+                if ($fill) {
+                    $id = sanitize_title($fill);
+                } else {
+                    $id = 'layer_' . $index;
+                }
+            }
+            $layers[$id] = [
+                'defaultGroup' => '',
+                'editable'     => false,
+            ];
+            $index++;
+        }
+        return $layers;
+    }
+
+    /**
+     * Provide available logos for product configuration.
+     */
+    public static function filter_available_logos($logos) {
+        $stored = get_option('fpc_predefined_logos', []);
+        foreach ($stored as $slug => $data) {
+            $logos[$slug] = $data['label'] ?? $slug;
+        }
+        return $logos;
+    }
+}
+
+// Register filter to expose predefined logos.
+add_filter('fpc_available_logos', ['FPC_SVG_Logo', 'filter_available_logos']);

--- a/printed-product-customizer.php
+++ b/printed-product-customizer.php
@@ -50,6 +50,7 @@ function fpc_init() {
     // Load admin menus
     if (is_admin()) {
         require_once FPC_PLUGIN_DIR . 'admin/menu-filament.php';
+        require_once FPC_PLUGIN_DIR . 'admin/menu-logos.php';
         require_once FPC_PLUGIN_DIR . 'admin/product-tab-filament-groups.php';
         require_once FPC_PLUGIN_DIR . 'admin/product-tab-subgroups.php';
         require_once FPC_PLUGIN_DIR . 'admin/product-tab-3mf-mapping.php';
@@ -61,6 +62,7 @@ function fpc_init() {
     require_once FPC_PLUGIN_DIR . 'includes/class-filament-sync.php';
     require_once FPC_PLUGIN_DIR . 'includes/class-product-config.php';
     require_once FPC_PLUGIN_DIR . 'includes/class-variation-pricing.php';
+    require_once FPC_PLUGIN_DIR . 'includes/class-svg-logo.php';
     require_once FPC_PLUGIN_DIR . 'includes/helpers.php';
 }
 
@@ -71,4 +73,11 @@ function fpc_admin_scripts($hook) {
         return;
     }
     wp_enqueue_script('fpc-admin', FPC_PLUGIN_URL . 'admin/assets/admin.js', ['jquery'], FPC_VERSION, true);
+}
+
+// Allow SVG uploads for logo management
+add_filter('upload_mimes', 'fpc_allow_svg_upload');
+function fpc_allow_svg_upload($mimes) {
+    $mimes['svg'] = 'image/svg+xml';
+    return $mimes;
 }


### PR DESCRIPTION
## Summary
- allow uploading SVG logos via new WooCommerce submenu
- sanitize and parse SVG layers for logo configurations
- enable SVG mime type and expose stored logos to product tabs

## Testing
- `php -l printed-product-customizer.php`
- `php -l includes/class-svg-logo.php`
- `php -l admin/menu-logos.php`


------
https://chatgpt.com/codex/tasks/task_e_6893f008ac008332b3efd3d1396cdf66