### PR TITLE
Add brand and transparency fields to filament sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Initial scaffold for a WordPress/WooCommerce plugin that enables configuration o
 1. Navigate to **WooCommerce → Filament Inventory** in the WordPress admin.
 2. Enter your Google API key and full Google Sheet URL (e.g. `https://docs.google.com/spreadsheets/d/XYZ/edit#gid=123`) and save settings. The plugin will automatically extract the sheet and tab information.
 3. Click **Sync Now** to fetch filament data.
-4. The sheet must have a header row with columns: `slug`, `material`, `price_per_kg`, `stock_grams`, `color`, `texture`.
+4. The sheet must have a header row with columns: `slug`, `brand`, `material`, `price_per_kg`, `stock_grams`, `color`, `Color`, `texture`, `transparency`.
 
 This repository currently contains minimal placeholders intended for further development.

--- a/admin/menu-filament.php
+++ b/admin/menu-filament.php
@@ -130,21 +130,28 @@ function fpc_render_filament_inventory_page() {
         echo '<table class="widefat">';
         echo '<thead><tr>';
         echo '<th>' . esc_html__('Slug', 'printed-product-customizer') . '</th>';
+        echo '<th>' . esc_html__('Brand', 'printed-product-customizer') . '</th>';
         echo '<th>' . esc_html__('Material', 'printed-product-customizer') . '</th>';
         echo '<th>' . esc_html__('Price/kg', 'printed-product-customizer') . '</th>';
         echo '<th>' . esc_html__('Stock (g)', 'printed-product-customizer') . '</th>';
         echo '<th>' . esc_html__('Color', 'printed-product-customizer') . '</th>';
+        echo '<th>' . esc_html__('Color Name', 'printed-product-customizer') . '</th>';
+        echo '<th>' . esc_html__('Transparency', 'printed-product-customizer') . '</th>';
         echo '<th>' . esc_html__('Texture', 'printed-product-customizer') . '</th>';
         echo '</tr></thead><tbody>';
 
         foreach ($inventory as $slug => $data) {
             echo '<tr>';
             echo '<td>' . esc_html($slug) . '</td>';
+            echo '<td>' . esc_html($data['brand'] ?? '') . '</td>';
             echo '<td>' . esc_html($data['material'] ?? '') . '</td>';
             echo '<td>' . esc_html($data['price_per_kg'] ?? '') . '</td>';
             echo '<td>' . esc_html($data['stock_grams'] ?? '') . '</td>';
-            $color = $data['color'] ?? '';
-            echo '<td><span style="display:inline-block;width:20px;height:20px;background:' . esc_attr($color) . ';"></span> ' . esc_html($color) . '</td>';
+            $color   = $data['color'] ?? '';
+            $opacity = isset($data['opacity']) ? $data['opacity'] : 1;
+            echo '<td><span style="display:inline-block;width:20px;height:20px;background:' . esc_attr($color) . ';opacity:' . esc_attr($opacity) . ';"></span> ' . esc_html($color) . '</td>';
+            echo '<td>' . esc_html($data['color_name'] ?? '') . '</td>';
+            echo '<td>' . esc_html($data['transparency'] ?? '') . '</td>';
             echo '<td>' . esc_html($data['texture'] ?? '') . '</td>';
             echo '</tr>';
         }


### PR DESCRIPTION
## Summary
- sync new fields Brand, Color name, and transparency from Google Sheets
- map transparency to opacity and expose for front-end visualizer
- show new fields on Filament Inventory admin table

## Testing
- `php -l includes/class-filament-sync.php`
- `php -l admin/menu-filament.php`


------
https://chatgpt.com/codex/tasks/task_e_68941ceeb9c88332aa15dd1d299bfe0d