### PR TITLE
Revamp filament group UI

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -13,6 +13,49 @@ jQuery(function($){
             }
         });
         container.append(template);
+        updateFilamentOptions(template);
+        $(document.body).trigger('wc-enhanced-select-init');
+    }
+
+    function updateFilamentOptions($row){
+        var inventory = window.fpcFilamentInventory || {};
+        var materials = $row.find('.fpc-materials').val() || [];
+        var blacklist = $row.find('.fpc-filament-blacklist').val() || [];
+
+        function buildOptions(filter){
+            var html = '';
+            $.each(inventory, function(slug, data){
+                if(materials.length && materials.indexOf(data.material) === -1){
+                    return;
+                }
+                if(filter && !filter(slug)){
+                    return;
+                }
+                html += '<option value="'+slug+'">'+slug+'</option>';
+            });
+            return html;
+        }
+
+        var blacklistOptions = buildOptions();
+        var $blacklist = $row.find('.fpc-filament-blacklist');
+        var blacklistVal = $blacklist.val() || [];
+        $blacklist.html(blacklistOptions).val(blacklistVal).trigger('change');
+
+        var filterFn = function(slug){ return blacklist.indexOf(slug) === -1; };
+        var filteredOptions = buildOptions(filterFn);
+
+        var $default = $row.find('.fpc-default-filament');
+        var defaultVal = $default.val();
+        $default.html('<option value=""></option>'+filteredOptions);
+        if(defaultVal && $default.find('option[value="'+defaultVal+'"]').length){
+            $default.val(defaultVal);
+        }
+        $default.trigger('change');
+
+        var $whitelist = $row.find('.fpc-filament-whitelist');
+        var whitelistVal = $whitelist.val() || [];
+        $whitelist.html(filteredOptions);
+        $whitelist.val(whitelistVal.filter(function(v){ return $whitelist.find('option[value="'+v+'"]').length; })).trigger('change');
     }
 
     $('.fpc-repeatable-add').on('click', function(e){
@@ -36,6 +79,15 @@ jQuery(function($){
     $(document).on('change', '.fpc-key-field', function(){
         $(this).data('edited', true);
     });
+
+    $(document).on('change', '.fpc-materials, .fpc-filament-blacklist', function(){
+        updateFilamentOptions($(this).closest('.fpc-repeatable-row'));
+    });
+
+    $('.fpc-repeatable-row').each(function(){
+        updateFilamentOptions($(this));
+    });
+    $(document.body).trigger('wc-enhanced-select-init');
 
     function addPriceRow(container){
         var template = container.find('.fpc-template').first().clone();


### PR DESCRIPTION
## Summary
- Build filament group controls from synced inventory with tag-style selectors and override options
- Persist whitelist/blacklist arrays and override settings

## Testing
- `php -l admin/product-tab-filament-groups.php`
- `node --check admin/assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68943863c3b8833282c8949a9b763828