### PR TITLE
Use tag input for subgroup allowed filament groups and drop forced group

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -1,6 +1,37 @@
 jQuery(function($){
     console.log('Printed Product Customizer admin loaded');
 
+    function initTagInputs($inputs){
+        $inputs.each(function(){
+            var $input = $(this);
+            var options = $input.data('options') || [];
+            if(typeof options === 'string'){
+                try { options = JSON.parse(options); } catch(e){ options = options.split(','); }
+            }
+            function split(val){ return val.split(/,\s*/); }
+            function extractLast(term){ return split(term).pop(); }
+            $input.on('keydown', function(event){
+                if(event.keyCode === $.ui.keyCode.TAB && $input.autocomplete('instance') && $input.autocomplete('instance').menu.active){
+                    event.preventDefault();
+                }
+            }).autocomplete({
+                minLength:0,
+                source:function(request, response){
+                    response($.ui.autocomplete.filter(options, extractLast(request.term)));
+                },
+                focus:function(){ return false; },
+                select:function(event, ui){
+                    var terms = split(this.value);
+                    terms.pop();
+                    terms.push(ui.item.value);
+                    terms.push('');
+                    this.value = terms.join(', ');
+                    return false;
+                }
+            });
+        });
+    }
+
     function addRow(container){
         var template = container.find('.fpc-template').first().clone();
         template.removeClass('fpc-template').show();
@@ -13,6 +44,7 @@ jQuery(function($){
             }
         });
         container.append(template);
+        initTagInputs(template.find('.fpc-tag-input'));
     }
 
     $('.fpc-repeatable-add').on('click', function(e){
@@ -60,4 +92,6 @@ jQuery(function($){
         e.preventDefault();
         $(this).closest('.fpc-price-row').remove();
     });
+
+    initTagInputs($('.fpc-tag-input'));
 });

--- a/printed-product-customizer.php
+++ b/printed-product-customizer.php
@@ -74,7 +74,7 @@ function fpc_admin_scripts($hook) {
     if (strpos($hook, 'woocommerce') === false && !in_array($hook, ['post.php', 'post-new.php'], true)) {
         return;
     }
-    wp_enqueue_script('fpc-admin', FPC_PLUGIN_URL . 'admin/assets/admin.js', ['jquery'], FPC_VERSION, true);
+    wp_enqueue_script('fpc-admin', FPC_PLUGIN_URL . 'admin/assets/admin.js', ['jquery', 'jquery-ui-autocomplete'], FPC_VERSION, true);
 }
 
 // Allow SVG uploads for logo management


### PR DESCRIPTION
## Summary
- Replace subgroup Allowed Filament Groups multi-select with a tag-style autocomplete input using available group keys
- Remove Forced Filament Group option and drop related meta field
- Add tag-input initialization JS and enqueue jQuery UI Autocomplete

## Testing
- `php -l admin/product-tab-subgroups.php`
- `php -l printed-product-customizer.php`
- `node --check admin/assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68943879ac808332b5bde81a5e6a4e6e