### PR TITLE
Add update bodies button for 3MF mapping

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -280,5 +280,40 @@ jQuery(function($){
             }
         });
     });
+
+    $('#fpc-update-bodies').on('click', function(e){
+        e.preventDefault();
+        var btn = $(this);
+        var panel = $('#fpc_3mf_mapping_panel');
+        var formData = new FormData();
+        formData.append('action', 'fpc_update_bodies');
+        formData.append('post_id', $('#post_ID').val());
+        btn.prop('disabled', true);
+        panel.find('.fpc-save-notice').hide();
+        $.ajax({
+            url: ajaxurl,
+            type: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            success: function(resp){
+                btn.prop('disabled', false);
+                if(resp.success){
+                    var container = panel.find('.fpc-repeatable-container');
+                    container.find('.fpc-repeatable-row').not('.fpc-template').remove();
+                    $.each(resp.data.assignments, function(i, as){
+                        addRow(container, as);
+                    });
+                    panel.find('.fpc-save-notice').text(resp.data.message).show();
+                } else {
+                    panel.find('.fpc-save-notice').text(resp.data && resp.data.message ? resp.data.message : 'Error').show();
+                }
+            },
+            error: function(){
+                btn.prop('disabled', false);
+                panel.find('.fpc-save-notice').text('Error').show();
+            }
+        });
+    });
     initTagInputs($('.fpc-tag-input'));
 });


### PR DESCRIPTION
## Summary
- add update bodies button beside save 3MF files
- support refreshing body list from stored 3MF files via new AJAX handler
- update admin JS to call endpoint and rebuild assignments table

## Testing
- `php -l admin/product-tab-3mf-mapping.php`
- `node --check admin/assets/admin.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689443c2ef1c8332addd5b97a8f6215f