### PR TITLE
Default PETG materials for filament groups

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -49,6 +49,9 @@ jQuery(function($){
             template.find('.fpc-no-visualization-field').prop('checked', data.no_visualization === '1');
             template.find('.fpc-non-exported-field').prop('checked', data.non_exported === '1');
             template.find('.fpc-finish-field').val(data.finish || '');
+        } else {
+            template.find('.fpc-materials').val(['PETG']);
+            template.find('.fpc-default-filament').val('psm-m-bk-petg');
         }
         container.append(template);
         updateFilamentOptions(template);
@@ -134,6 +137,10 @@ jQuery(function($){
                 }
             }
         });
+        if(!data || $.isEmptyObject(data)){
+            template.find('.fpc-materials').val(['PETG']);
+            template.find('.fpc-default-filament').val('psm-m-bk-petg');
+        }
         $container.append(template);
         updateFilamentOptions(template);
         updateGroupTitle(template);

--- a/admin/product-tab-filament-groups.php
+++ b/admin/product-tab-filament-groups.php
@@ -61,15 +61,17 @@ function fpc_filament_groups_product_data_panel() {
                             <input type="checkbox" name="fpc_filament_groups[__INDEX__][required]" value="1" />
                         </p>
                         <p class="form-field">
-                            <label><?php _e('Default Filament', 'printed-product-customizer'); ?></label>
-                            <select class="fpc-default-filament wc-enhanced-select" style="width:100%;" name="fpc_filament_groups[__INDEX__][default_filament]"></select>
-                        </p>
-                        <p class="form-field">
                             <label><?php _e('Allowed Materials', 'printed-product-customizer'); ?></label>
                             <select class="fpc-materials wc-enhanced-select" multiple="multiple" style="width:100%;" name="fpc_filament_groups[__INDEX__][materials][]">
                                 <?php foreach ($materials_list as $mat) : ?>
-                                    <option value="<?php echo esc_attr($mat); ?>"><?php echo esc_html($mat); ?></option>
+                                    <option value="<?php echo esc_attr($mat); ?>" <?php selected($mat, 'PETG'); ?>><?php echo esc_html($mat); ?></option>
                                 <?php endforeach; ?>
+                            </select>
+                        </p>
+                        <p class="form-field">
+                            <label><?php _e('Default Filament', 'printed-product-customizer'); ?></label>
+                            <select class="fpc-default-filament wc-enhanced-select" style="width:100%;" name="fpc_filament_groups[__INDEX__][default_filament]">
+                                <option value="psm-m-bk-petg" selected></option>
                             </select>
                         </p>
                         <p class="form-field">
@@ -136,19 +138,19 @@ function fpc_filament_groups_product_data_panel() {
                             }, ARRAY_FILTER_USE_BOTH);
                             ?>
                             <p class="form-field">
+                                <label><?php _e('Allowed Materials', 'printed-product-customizer'); ?></label>
+                                <select class="fpc-materials wc-enhanced-select" multiple="multiple" style="width:100%;" name="fpc_filament_groups[<?php echo esc_attr($index); ?>][materials][]">
+                                    <?php foreach ($materials_list as $mat) : ?>
+                                        <option value="<?php echo esc_attr($mat); ?>" <?php selected(in_array($mat, $materials, true)); ?>><?php echo esc_html($mat); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </p>
+                            <p class="form-field">
                                 <label><?php _e('Default Filament', 'printed-product-customizer'); ?></label>
                                 <select class="fpc-default-filament wc-enhanced-select" style="width:100%;" name="fpc_filament_groups[<?php echo esc_attr($index); ?>][default_filament]">
                                     <option value=""></option>
                                     <?php foreach ($filtered_no_blacklist as $slug => $item) : ?>
                                         <option value="<?php echo esc_attr($slug); ?>" <?php selected($group['default_filament'] ?? '', $slug); ?>><?php echo esc_html($slug); ?></option>
-                                    <?php endforeach; ?>
-                                </select>
-                            </p>
-                            <p class="form-field">
-                                <label><?php _e('Allowed Materials', 'printed-product-customizer'); ?></label>
-                                <select class="fpc-materials wc-enhanced-select" multiple="multiple" style="width:100%;" name="fpc_filament_groups[<?php echo esc_attr($index); ?>][materials][]">
-                                    <?php foreach ($materials_list as $mat) : ?>
-                                        <option value="<?php echo esc_attr($mat); ?>" <?php selected(in_array($mat, $materials, true)); ?>><?php echo esc_html($mat); ?></option>
                                     <?php endforeach; ?>
                                 </select>
                             </p>


### PR DESCRIPTION
## Summary
- reorder filament group fields so allowed materials precede default filament
- ensure default, whitelist, and blacklist selectors respect allowed materials with PETG and `psm-m-bk-petg` preselected

## Testing
- `php -l admin/product-tab-filament-groups.php`
- `node --check admin/assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6894438c601883329f318edb5154fbb7