### PR TITLE
Add filament exemption options and adjust fee logic

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -56,6 +56,7 @@ jQuery(function($){
         container.append(template);
         updateFilamentOptions(template);
         updateGroupTitle(template);
+        toggleExemptFilaments(template);
         $(document.body).trigger('wc-enhanced-select-init');
     }
 
@@ -98,6 +99,11 @@ jQuery(function($){
         var whitelistVal = $whitelist.val() || [];
         $whitelist.html(filteredOptions);
         $whitelist.val(whitelistVal.filter(function(v){ return $whitelist.find('option[value="'+v+'"]').length; })).trigger('change');
+
+        var $exempt = $row.find('.fpc-exempt-filaments');
+        var exemptVal = $exempt.val() || [];
+        $exempt.html(filteredOptions);
+        $exempt.val(exemptVal.filter(function(v){ return $exempt.find('option[value="'+v+'"]').length; })).trigger('change');
     }
 
     function updateGroupTitle($row){
@@ -144,6 +150,7 @@ jQuery(function($){
         $container.append(template);
         updateFilamentOptions(template);
         updateGroupTitle(template);
+        toggleExemptFilaments(template);
         $(document.body).trigger('wc-enhanced-select-init');
         $container.data('initialized', true);
     }
@@ -176,9 +183,27 @@ jQuery(function($){
         updateFilamentOptions($(this).closest('.fpc-repeatable-row'));
     });
 
+    function toggleExemptFilaments($row){
+        var $all = $row.find('.fpc-exempt-all');
+        var $field = $row.find('.fpc-exempt-filaments-field');
+        var $select = $row.find('.fpc-exempt-filaments');
+        if($all.is(':checked')){
+            $select.prop('disabled', true);
+            $field.hide();
+        } else {
+            $select.prop('disabled', false);
+            $field.show();
+        }
+    }
+
+    $(document).on('change', '.fpc-exempt-all', function(){
+        toggleExemptFilaments($(this).closest('.fpc-repeatable-row'));
+    });
+
     $('.fpc-repeatable-row').each(function(){
         updateFilamentOptions($(this));
         updateGroupTitle($(this));
+        toggleExemptFilaments($(this));
     });
     $(document.body).trigger('wc-enhanced-select-init');
 

--- a/admin/product-tab-filament-groups.php
+++ b/admin/product-tab-filament-groups.php
@@ -96,6 +96,14 @@ function fpc_filament_groups_product_data_panel() {
                             <select class="fpc-filament-blacklist wc-enhanced-select" multiple="multiple" style="width:100%;" name="fpc_filament_groups[__INDEX__][filament_blacklist][]"></select>
                         </p>
                         <p class="form-field">
+                            <label><?php _e('Exempt all Filaments', 'printed-product-customizer'); ?></label>
+                            <input type="checkbox" class="fpc-exempt-all" name="fpc_filament_groups[__INDEX__][exempt_all_filaments]" value="1" />
+                        </p>
+                        <p class="form-field fpc-exempt-filaments-field">
+                            <label><?php _e('Exempt Filaments', 'printed-product-customizer'); ?></label>
+                            <select class="fpc-exempt-filaments wc-enhanced-select" multiple="multiple" style="width:100%;" name="fpc_filament_groups[__INDEX__][exempt_filaments][]"></select>
+                        </p>
+                        <p class="form-field">
                             <label><?php _e('Base Grams', 'printed-product-customizer'); ?></label>
                             <input type="number" step="any" class="short" name="fpc_filament_groups[__INDEX__][base_grams]" />
                         </p>
@@ -135,6 +143,9 @@ function fpc_filament_groups_product_data_panel() {
                             });
                             $filtered_no_blacklist = array_filter($filtered, function($item, $slug) use ($blacklist) {
                                 return !in_array($slug, $blacklist, true);
+                            }, ARRAY_FILTER_USE_BOTH);
+                            $allowed_options = empty($whitelist) ? $filtered_no_blacklist : array_filter($filtered_no_blacklist, function($item, $slug) use ($whitelist) {
+                                return in_array($slug, $whitelist, true);
                             }, ARRAY_FILTER_USE_BOTH);
                             ?>
                             <p class="form-field">
@@ -180,6 +191,18 @@ function fpc_filament_groups_product_data_panel() {
                                 <select class="fpc-filament-blacklist wc-enhanced-select" multiple="multiple" style="width:100%;" name="fpc_filament_groups[<?php echo esc_attr($index); ?>][filament_blacklist][]">
                                     <?php foreach ($filtered as $slug => $item) : ?>
                                         <option value="<?php echo esc_attr($slug); ?>" <?php selected(in_array($slug, $blacklist, true)); ?>><?php echo esc_html($slug); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </p>
+                            <p class="form-field">
+                                <label><?php _e('Exempt all Filaments', 'printed-product-customizer'); ?></label>
+                                <input type="checkbox" class="fpc-exempt-all" name="fpc_filament_groups[<?php echo esc_attr($index); ?>][exempt_all_filaments]" value="1" <?php checked(!empty($group['exempt_all_filaments'])); ?> />
+                            </p>
+                            <p class="form-field fpc-exempt-filaments-field">
+                                <label><?php _e('Exempt Filaments', 'printed-product-customizer'); ?></label>
+                                <select class="fpc-exempt-filaments wc-enhanced-select" multiple="multiple" style="width:100%;" name="fpc_filament_groups[<?php echo esc_attr($index); ?>][exempt_filaments][]">
+                                    <?php $exempt = $group['exempt_filaments'] ?? []; foreach ($allowed_options as $slug => $item) : ?>
+                                        <option value="<?php echo esc_attr($slug); ?>" <?php selected(in_array($slug, $exempt, true)); ?>><?php echo esc_html($slug); ?></option>
                                     <?php endforeach; ?>
                                 </select>
                             </p>
@@ -234,6 +257,8 @@ function fpc_filament_groups_save($post_id) {
                 'materials'       => array_map('sanitize_text_field', $group['materials'] ?? []),
                 'filament_whitelist' => array_map('sanitize_text_field', $group['filament_whitelist'] ?? []),
                 'filament_blacklist' => array_map('sanitize_text_field', $group['filament_blacklist'] ?? []),
+                'exempt_all_filaments' => !empty($group['exempt_all_filaments']) ? 1 : 0,
+                'exempt_filaments' => array_map('sanitize_text_field', $group['exempt_filaments'] ?? []),
                 'allow_override'  => !empty($group['allow_override']) ? 1 : 0,
                 'override_message'=> sanitize_text_field($group['override_message'] ?? ''),
                 'override_surcharge' => floatval($group['override_surcharge'] ?? 0),
@@ -263,6 +288,8 @@ function fpc_filament_groups_save($post_id) {
             'materials'       => array_map('sanitize_text_field', $group['materials'] ?? []),
             'filament_whitelist' => array_map('sanitize_text_field', $group['filament_whitelist'] ?? []),
             'filament_blacklist' => array_map('sanitize_text_field', $group['filament_blacklist'] ?? []),
+            'exempt_all_filaments' => !empty($group['exempt_all_filaments']) ? 1 : 0,
+            'exempt_filaments' => array_map('sanitize_text_field', $group['exempt_filaments'] ?? []),
             'allow_override'  => !empty($group['allow_override']) ? 1 : 0,
             'override_message'=> sanitize_text_field($group['override_message'] ?? ''),
             'override_surcharge' => floatval($group['override_surcharge'] ?? 0),

--- a/includes/class-variation-pricing.php
+++ b/includes/class-variation-pricing.php
@@ -9,6 +9,7 @@ if (!defined('ABSPATH')) {
 class FPC_Variation_Pricing {
     public function __construct() {
         add_action('woocommerce_before_calculate_totals', [$this, 'apply_pricing']);
+        add_action('woocommerce_cart_calculate_fees', [$this, 'apply_filament_fee']);
     }
 
     /**
@@ -24,6 +25,49 @@ class FPC_Variation_Pricing {
                 $price = $cart_item['data']->get_price();
                 $cart_item['data']->set_price($price * 0.9); // 10% discount as placeholder
             }
+        }
+    }
+
+    /**
+     * Apply filament change fees while honoring exemptions.
+     */
+    public function apply_filament_fee($cart) {
+        if (is_admin() && !defined('DOING_AJAX')) {
+            return;
+        }
+
+        $unique = [];
+        $exempt_slugs = [];
+
+        foreach ($cart->get_cart() as $cart_item) {
+            $product_id = $cart_item['product_id'] ?? 0;
+            $groups = FPC_Product_Config::get_filament_groups($product_id);
+            $selected = $cart_item['fpc_filaments'] ?? [];
+            if (!is_array($groups)) {
+                continue;
+            }
+            foreach ($groups as $group) {
+                $exempt_slugs = array_merge($exempt_slugs, $group['exempt_filaments'] ?? []);
+                if (!empty($group['exempt_all_filaments'])) {
+                    continue;
+                }
+                $key = $group['key'] ?? '';
+                if (!$key) {
+                    continue;
+                }
+                $slug = $selected[$key] ?? '';
+                if (!$slug) {
+                    continue;
+                }
+                $unique[$slug] = true;
+            }
+        }
+
+        $unique = array_diff_key($unique, array_flip($exempt_slugs));
+        $count = count($unique);
+        $fee_per_change = floatval(get_option('fpc_filament_change_fee', 0));
+        if ($fee_per_change > 0 && $count > 1) {
+            $cart->add_fee(__('Filament Change Fee', 'printed-product-customizer'), ($count - 1) * $fee_per_change);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add "Exempt all Filaments" and "Exempt Filaments" controls to filament group settings
- populate and toggle new exemption fields in admin JS
- honor filament exemptions when saving metadata and computing change fees

## Testing
- `php -l admin/product-tab-filament-groups.php`
- `php -l includes/class-variation-pricing.php`
- `node --check admin/assets/admin.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944b342f1c8332ba3a89afcc6fded4