### PR TITLE
Add optional additional group fee

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -119,6 +119,7 @@ jQuery(function($){
         template.attr('data-default-title', label);
         template.find('.fpc-group-title').text(label);
         template.find('.fpc-repeatable-remove').remove();
+        template.find('.fpc-additional-fee-field').show();
         template.find(':input').each(function(){
             var name = $(this).attr('name');
             if(name){

--- a/admin/product-tab-filament-groups.php
+++ b/admin/product-tab-filament-groups.php
@@ -107,6 +107,10 @@ function fpc_filament_groups_product_data_panel() {
                             <label><?php _e('Max Price/kg before surcharge', 'printed-product-customizer'); ?></label>
                             <input type="number" step="any" class="short" name="fpc_filament_groups[__INDEX__][max_price]" />
                         </p>
+                        <p class="form-field fpc-additional-fee-field" style="display:none;">
+                            <label><?php _e('Additional Group Fee', 'printed-product-customizer'); ?></label>
+                            <input type="number" step="any" class="short" name="fpc_filament_groups[__INDEX__][additional_group_fee]" />
+                        </p>
                         <p><button type="button" class="button fpc-repeatable-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button></p>
                     </div>
                 </div>
@@ -269,6 +273,7 @@ function fpc_filament_groups_save($post_id) {
             'base_grams'      => floatval($group['base_grams'] ?? 0),
             'waste_grams'     => floatval($group['waste_grams'] ?? 0),
             'max_price'       => floatval($group['max_price'] ?? 0),
+            'additional_group_fee' => floatval($group['additional_group_fee'] ?? 0),
         ];
         update_post_meta($post_id, '_fpc_additional_group_rules', $rules);
     } else {

--- a/includes/class-variation-pricing.php
+++ b/includes/class-variation-pricing.php
@@ -20,10 +20,31 @@ class FPC_Variation_Pricing {
         }
 
         foreach ($cart->get_cart() as $cart_item) {
-            if ($cart_item['quantity'] > 1) {
-                $price = $cart_item['data']->get_price();
-                $cart_item['data']->set_price($price * 0.9); // 10% discount as placeholder
+            $price = $cart_item['data']->get_price();
+
+            // Apply fees for any unique filaments beyond the default group count.
+            $product_id = $cart_item['product_id'];
+            $rules = get_post_meta($product_id, '_fpc_additional_group_rules', true);
+            $fee   = isset($rules['additional_group_fee']) ? (float) $rules['additional_group_fee'] : 0;
+            if ($fee > 0) {
+                $defined_groups = get_post_meta($product_id, '_fpc_filament_groups', true);
+                $base_count     = is_array($defined_groups) ? count($defined_groups) : 0;
+
+                $defaults   = array_filter(array_map('sanitize_text_field', (array) ($cart_item['fpc_filaments'] ?? [])));
+                $additional = array_filter(array_map('sanitize_text_field', (array) ($cart_item['fpc_additional_groups'] ?? [])));
+                $unique     = count(array_unique(array_merge($defaults, $additional)));
+
+                $extra = max(0, $unique - $base_count);
+                if ($extra > 0) {
+                    $price += $fee * $extra;
+                }
             }
+
+            if ($cart_item['quantity'] > 1) {
+                $price *= 0.9; // 10% discount as placeholder
+            }
+
+            $cart_item['data']->set_price($price);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add admin field to set an optional fee for each additional filament group
- save new field with additional group rules and expose it in variation pricing
- calculate charges only when the total number of unique filaments exceeds the predefined group count

## Testing
- `php -l admin/product-tab-filament-groups.php`
- `php -l includes/class-variation-pricing.php`
- `node -e "new Function(require('fs').readFileSync('admin/assets/admin.js','utf8'));"`


------
https://chatgpt.com/codex/tasks/task_e_68944b2aee248332b4c30faa195208c5