### PR TITLE
Default exotic surcharge and fix filament group UI

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -204,18 +204,24 @@ jQuery(function($){
         updateFilamentOptions($(this));
         updateGroupTitle($(this));
         toggleExemptFilaments($(this));
+        $(this).find('.fpc-group-fields').hide();
     });
     $(document.body).trigger('wc-enhanced-select-init');
 
     $(document).on('click', '.fpc-group-toggle', function(e){
         e.preventDefault();
-        $(this).next('.fpc-group-fields').slideToggle();
+        $(this).closest('.fpc-repeatable-row').find('.fpc-group-fields').first().slideToggle();
     });
 
     $('.fpc-additional-rules-toggle').on('click', function(e){
         e.preventDefault();
         initAdditionalGroupRules(window.fpcAdditionalGroupRules || {});
-        $('#fpc-additional-rules').toggle();
+        var $container = $('#fpc-additional-rules');
+        $container.slideToggle(function(){
+            if($container.is(':visible')){
+                $(document.body).trigger('wc-enhanced-select-init');
+            }
+        });
     });
 
     if(window.fpcAdditionalGroupRules && Object.keys(window.fpcAdditionalGroupRules).length){

--- a/admin/product-tab-filament-groups.php
+++ b/admin/product-tab-filament-groups.php
@@ -109,7 +109,7 @@ function fpc_filament_groups_product_data_panel() {
                         </p>
                         <p class="form-field">
                             <label><?php _e('Apply Exotic Surcharge', 'printed-product-customizer'); ?></label>
-                            <input type="checkbox" name="fpc_filament_groups[__INDEX__][apply_exotic_fee]" value="1" />
+                            <input type="checkbox" name="fpc_filament_groups[__INDEX__][apply_exotic_fee]" value="1" checked="checked" />
                         </p>
                         <p class="form-field">
                             <label><?php _e('Max Free Price/kg', 'printed-product-customizer'); ?></label>


### PR DESCRIPTION
## Summary
- Check the "Apply Exotic Surcharge" box by default for new filament groups
- Ensure filament group panels collapse reliably and initialize additional group fields when shown

## Testing
- `php -l admin/product-tab-filament-groups.php`
- `node --check admin/assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_689456cadd708332867e404754e8cfb4