### PR TITLE
Add debug logging for 3MF mapping

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -301,6 +301,8 @@ jQuery(function($){
         var btn = $(this);
         var panel = $('#fpc_3mf_mapping_panel');
         var filesInput = panel.find('input[name="fpc_3mf_files[]"]')[0];
+        console.log('fpc-save-3mf: clicked');
+        console.log('fpc-save-3mf: files selected', filesInput && filesInput.files ? filesInput.files.length : 0);
         var formData = new FormData();
         formData.append('action', 'fpc_save_3mf_files');
         formData.append('post_id', $('#post_ID').val());
@@ -311,6 +313,7 @@ jQuery(function($){
         }
         btn.prop('disabled', true);
         panel.find('.fpc-save-notice').hide();
+        console.log('fpc-save-3mf: sending ajax');
         $.ajax({
             url: ajaxurl,
             type: 'POST',
@@ -319,6 +322,7 @@ jQuery(function($){
             contentType: false,
             success: function(resp){
                 btn.prop('disabled', false);
+                console.log('fpc-save-3mf: response', resp);
                 if(resp.success){
                     var container = panel.find('.fpc-repeatable-container');
                     container.find('.fpc-repeatable-row').not('.fpc-template').remove();
@@ -330,8 +334,9 @@ jQuery(function($){
                     panel.find('.fpc-save-notice').text(resp.data && resp.data.message ? resp.data.message : 'Error').show();
                 }
             },
-            error: function(){
+            error: function(err){
                 btn.prop('disabled', false);
+                console.error('fpc-save-3mf: ajax error', err);
                 panel.find('.fpc-save-notice').text('Error').show();
             }
         });
@@ -344,8 +349,10 @@ jQuery(function($){
         var formData = new FormData();
         formData.append('action', 'fpc_update_bodies');
         formData.append('post_id', $('#post_ID').val());
+        console.log('fpc-update-bodies: clicked');
         btn.prop('disabled', true);
         panel.find('.fpc-save-notice').hide();
+        console.log('fpc-update-bodies: sending ajax');
         $.ajax({
             url: ajaxurl,
             type: 'POST',
@@ -354,6 +361,7 @@ jQuery(function($){
             contentType: false,
             success: function(resp){
                 btn.prop('disabled', false);
+                console.log('fpc-update-bodies: response', resp);
                 if(resp.success){
                     var container = panel.find('.fpc-repeatable-container');
                     container.find('.fpc-repeatable-row').not('.fpc-template').remove();
@@ -365,8 +373,9 @@ jQuery(function($){
                     panel.find('.fpc-save-notice').text(resp.data && resp.data.message ? resp.data.message : 'Error').show();
                 }
             },
-            error: function(){
+            error: function(err){
                 btn.prop('disabled', false);
+                console.error('fpc-update-bodies: ajax error', err);
                 panel.find('.fpc-save-notice').text('Error').show();
             }
         });

--- a/admin/product-tab-3mf-mapping.php
+++ b/admin/product-tab-3mf-mapping.php
@@ -112,10 +112,12 @@ function fpc_3mf_mapping_product_data_panel() {
 
 add_action('woocommerce_process_product_meta', 'fpc_3mf_mapping_save');
 function fpc_3mf_mapping_save($post_id) {
+    error_log('fpc_3mf_mapping_save: start for post ' . $post_id);
     $existing_files = get_post_meta($post_id, '_fpc_3mf_files', true);
     $existing_files = is_array($existing_files) ? $existing_files : [];
 
     if (!empty($_FILES['fpc_3mf_files']['name'][0])) {
+        error_log('fpc_3mf_mapping_save: files received ' . print_r($_FILES['fpc_3mf_files']['name'], true));
         $uploaded = [];
         require_once ABSPATH . 'wp-admin/includes/file.php';
         require_once ABSPATH . 'wp-admin/includes/image.php';
@@ -141,12 +143,16 @@ function fpc_3mf_mapping_save($post_id) {
                     $attach_id = wp_insert_attachment($attachment, $movefile['file'], $post_id);
                     wp_update_attachment_metadata($attach_id, wp_generate_attachment_metadata($attach_id, $movefile['file']));
                     $uploaded[] = $attach_id;
+                    error_log('fpc_3mf_mapping_save: uploaded ' . $name . ' as attachment ' . $attach_id);
+                } else {
+                    error_log('fpc_3mf_mapping_save: error uploading ' . $name . ' - ' . $movefile['error']);
                 }
             }
         }
         if ($uploaded) {
             $existing_files = array_merge($existing_files, $uploaded);
             update_post_meta($post_id, '_fpc_3mf_files', $existing_files);
+            error_log('fpc_3mf_mapping_save: files saved ' . implode(',', $existing_files));
         }
     }
 
@@ -204,12 +210,14 @@ function fpc_3mf_ajax_save_files() {
     }
 
     $post_id = intval($_POST['post_id']);
+    error_log('fpc_3mf_ajax_save_files: start for post ' . $post_id);
 
     $existing_files = get_post_meta($post_id, '_fpc_3mf_files', true);
     $existing_files = is_array($existing_files) ? $existing_files : [];
 
     $uploaded = [];
     if (!empty($_FILES['fpc_3mf_files']['name'][0])) {
+        error_log('fpc_3mf_ajax_save_files: files received ' . print_r($_FILES['fpc_3mf_files']['name'], true));
         require_once ABSPATH . 'wp-admin/includes/file.php';
         require_once ABSPATH . 'wp-admin/includes/image.php';
         $files = $_FILES['fpc_3mf_files'];
@@ -234,6 +242,9 @@ function fpc_3mf_ajax_save_files() {
                     $attach_id = wp_insert_attachment($attachment, $movefile['file'], $post_id);
                     wp_update_attachment_metadata($attach_id, wp_generate_attachment_metadata($attach_id, $movefile['file']));
                     $uploaded[] = $attach_id;
+                    error_log('fpc_3mf_ajax_save_files: uploaded ' . $name . ' as attachment ' . $attach_id);
+                } else {
+                    error_log('fpc_3mf_ajax_save_files: error uploading ' . $name . ' - ' . $movefile['error']);
                 }
             }
         }
@@ -242,6 +253,7 @@ function fpc_3mf_ajax_save_files() {
     if ($uploaded) {
         $existing_files = array_merge($existing_files, $uploaded);
         update_post_meta($post_id, '_fpc_3mf_files', $existing_files);
+        error_log('fpc_3mf_ajax_save_files: files saved ' . implode(',', $existing_files));
     }
 
     $bodies = fpc_3mf_collect_bodies($existing_files);
@@ -270,6 +282,7 @@ function fpc_3mf_ajax_save_files() {
 
     update_post_meta($post_id, '_fpc_body_assignments', $assignments);
 
+    error_log('fpc_3mf_ajax_save_files: returning success with ' . count($assignments) . ' assignments');
     wp_send_json_success([
         'message'     => __('3MF files saved', 'printed-product-customizer'),
         'assignments' => $assignments,


### PR DESCRIPTION
## Summary
- add console logging to 3MF save and body update actions
- log PHP file upload steps for 3MF mapping debug

## Testing
- `php -l admin/product-tab-3mf-mapping.php`
- `node --check admin/assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_689504d271ac833281535209a677c4b0