### PR TITLE
Avoid saving empty text and logo zones

### DIFF
--- a/admin/product-tab-logo-zones.php
+++ b/admin/product-tab-logo-zones.php
@@ -178,9 +178,15 @@ function fpc_logo_zones_save($post_id) {
     if (isset($_POST['fpc_logo_zones']) && is_array($_POST['fpc_logo_zones'])) {
         $zones = [];
         foreach ($_POST['fpc_logo_zones'] as $zone) {
+            if (empty($zone['label']) && empty($zone['key']) && empty($zone['body'])) {
+                continue;
+            }
             $price_adjust = [];
             if (!empty($zone['price_adjust']) && is_array($zone['price_adjust'])) {
                 foreach ($zone['price_adjust'] as $pa) {
+                    if (empty($pa['logo']) && $pa['price'] === '') {
+                        continue;
+                    }
                     $price_adjust[] = [
                         'logo'  => sanitize_text_field($pa['logo'] ?? ''),
                         'price' => floatval($pa['price'] ?? 0),
@@ -190,6 +196,9 @@ function fpc_logo_zones_save($post_id) {
             $options = [];
             if (!empty($zone['options']) && is_array($zone['options'])) {
                 foreach ($zone['options'] as $op) {
+                    if (empty($op['logo'])) {
+                        continue;
+                    }
                     $options[] = [
                         'logo'     => sanitize_text_field($op['logo'] ?? ''),
                         'rotation' => floatval($op['rotation'] ?? 0),
@@ -255,7 +264,11 @@ function fpc_logo_zones_save($post_id) {
                 ],
             ];
         }
-        update_post_meta($post_id, '_fpc_logo_zones', $zones);
+        if (!empty($zones)) {
+            update_post_meta($post_id, '_fpc_logo_zones', $zones);
+        } else {
+            delete_post_meta($post_id, '_fpc_logo_zones');
+        }
     } else {
         delete_post_meta($post_id, '_fpc_logo_zones');
     }

--- a/admin/product-tab-text-zones.php
+++ b/admin/product-tab-text-zones.php
@@ -141,6 +141,9 @@ function fpc_text_zones_save($post_id) {
     if (isset($_POST['fpc_text_zones']) && is_array($_POST['fpc_text_zones'])) {
         $zones = [];
         foreach ($_POST['fpc_text_zones'] as $zone) {
+            if (empty($zone['label']) && empty($zone['key']) && empty($zone['body'])) {
+                continue;
+            }
             $zones[] = [
                 'label'           => sanitize_text_field($zone['label'] ?? ''),
                 'key'             => sanitize_title($zone['key'] ?? ''),
@@ -181,7 +184,11 @@ function fpc_text_zones_save($post_id) {
                 'changeover_fee'  => floatval($zone['changeover_fee'] ?? 0),
             ];
         }
-        update_post_meta($post_id, '_fpc_text_zones', $zones);
+        if (!empty($zones)) {
+            update_post_meta($post_id, '_fpc_text_zones', $zones);
+        } else {
+            delete_post_meta($post_id, '_fpc_text_zones');
+        }
     } else {
         delete_post_meta($post_id, '_fpc_text_zones');
     }


### PR DESCRIPTION
## Summary
- Ignore placeholder rows so empty text zones are not stored
- Skip saving blank logo zones, options, and price adjustments

## Testing
- `php -l admin/product-tab-text-zones.php`
- `php -l admin/product-tab-logo-zones.php`


------
https://chatgpt.com/codex/tasks/task_e_6895082686ec833282bc0949908a5cc2