### PR TITLE
Show additional group rules by default

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -231,20 +231,7 @@ jQuery(function($){
         $(this).closest('.fpc-repeatable-row').find('.fpc-group-fields').first().slideToggle();
     });
 
-    $('.fpc-additional-rules-toggle').on('click', function(e){
-        e.preventDefault();
-        initAdditionalGroupRules(window.fpcAdditionalGroupRules || {});
-        var $container = $('#fpc-additional-rules');
-        $container.slideToggle(function(){
-            if($container.is(':visible')){
-                $(document.body).trigger('wc-enhanced-select-init');
-            }
-        });
-    });
-
-    if(window.fpcAdditionalGroupRules && Object.keys(window.fpcAdditionalGroupRules).length){
-        initAdditionalGroupRules(window.fpcAdditionalGroupRules);
-    }
+    initAdditionalGroupRules(window.fpcAdditionalGroupRules || {});
 
     function addPriceRow(container){
         var template = container.find('.fpc-template').first().clone();

--- a/admin/product-tab-filament-groups.php
+++ b/admin/product-tab-filament-groups.php
@@ -236,8 +236,7 @@ function fpc_filament_groups_product_data_panel() {
                     <?php endfor; ?>
                 </select>
             </p>
-            <p><button type="button" class="button fpc-additional-rules-toggle"><?php _e('Additional Group Rules', 'printed-product-customizer'); ?></button></p>
-            <div id="fpc-additional-rules" data-label="<?php esc_attr_e('Additional Group Rules', 'printed-product-customizer'); ?>" style="display:none;"></div>
+            <div id="fpc-additional-rules" data-label="<?php esc_attr_e('Additional Group Rules', 'printed-product-customizer'); ?>"></div>
         </div>
     </div>
     <script type="text/javascript">


### PR DESCRIPTION
## Summary
- Display additional group rules on the product tab without requiring a toggle button
- Initialize additional group rules automatically when the page loads

## Testing
- `php -l admin/product-tab-filament-groups.php`
- `node --check admin/assets/admin.js`
- `npm test` *(fails: ENOENT package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689515817e5c83329d437bbfc0445cd8