### PR TITLE
Make admin groups collapsible

### DIFF
--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -53,6 +53,7 @@ jQuery(function($){
             template.find('.fpc-default-filament').val('psm-m-bk-petg');
         }
         container.append(template);
+        template.find('.fpc-group-fields').hide();
         updateFilamentOptions(template);
         updateGroupTitle(template);
         toggleExemptFilaments(template);
@@ -294,8 +295,11 @@ jQuery(function($){
                 $(this).attr('name', name);
             }
         });
-        container.append(template);
-    }
+    container.append(template);
+    template.find('.fpc-group-fields').hide();
+    updateGroupTitle(template);
+    $(document.body).trigger('wc-enhanced-select-init');
+}
 
     $(document).on('click', '.fpc-design-add', function(e){
         e.preventDefault();

--- a/admin/product-tab-design-zones.php
+++ b/admin/product-tab-design-zones.php
@@ -31,7 +31,9 @@ function fpc_design_zones_product_data_panel() {
     <div id="fpc_design_zones_panel" class="panel woocommerce_options_panel hidden">
         <div class="fpc-repeatable-wrapper">
             <div class="fpc-repeatable-container">
-                <div class="fpc-repeatable-row fpc-template" style="display:none;">
+                <div class="fpc-repeatable-row fpc-template" data-default-title="<?php esc_attr_e('Design Zone', 'printed-product-customizer'); ?>" style="display:none;">
+                    <h4 class="fpc-group-toggle"><span class="fpc-group-title"><?php _e('Design Zone', 'printed-product-customizer'); ?></span></h4>
+                    <div class="fpc-group-fields">
                     <p class="form-field"><label><?php _e('Label', 'printed-product-customizer'); ?></label><input type="text" class="short fpc-generate-key" name="fpc_design_zones[__INDEX__][label]" /></p>
                     <p class="form-field"><label><?php _e('Key', 'printed-product-customizer'); ?></label><input type="text" class="short fpc-key-field" name="fpc_design_zones[__INDEX__][key]" /></p>
                     <p class="form-field"><label><?php _e('Target Body', 'printed-product-customizer'); ?></label><select name="fpc_design_zones[__INDEX__][body]"><option value=""><?php _e('Select body', 'printed-product-customizer'); ?></option><?php foreach ($bodies as $b) : ?><option value="<?php echo esc_attr($b); ?>"><?php echo esc_html($b); ?></option><?php endforeach; ?></select></p>
@@ -41,31 +43,37 @@ function fpc_design_zones_product_data_panel() {
                         <label><?php _e('Designs', 'printed-product-customizer'); ?></label>
                         <div class="fpc-design-wrapper">
                             <div class="fpc-design-container">
-                                <div class="fpc-design-row fpc-template" style="display:none;">
-                                    <select name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][type]">
-                                        <option value="predefined">predefined</option>
-                                        <option value="custom_svg">custom_svg</option>
-                                        <option value="custom_text">custom_text</option>
-                                        <option value="blank">blank</option>
-                                    </select>
-                                    <input type="text" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][name]" placeholder="<?php esc_attr_e('Name', 'printed-product-customizer'); ?>" />
-                                    <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][price]" placeholder="<?php esc_attr_e('Price', 'printed-product-customizer'); ?>" />
-                                    <input type="text" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][text]" placeholder="<?php esc_attr_e('Text', 'printed-product-customizer'); ?>" />
-                                    <input type="text" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][file]" placeholder="<?php esc_attr_e('SVG File', 'printed-product-customizer'); ?>" />
-                                    <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][rotation]" placeholder="<?php esc_attr_e('Rotation', 'printed-product-customizer'); ?>" />
-                                    <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][scale]" placeholder="<?php esc_attr_e('Scale', 'printed-product-customizer'); ?>" />
-                                    <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][x]" placeholder="<?php esc_attr_e('X', 'printed-product-customizer'); ?>" />
-                                    <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][y]" placeholder="<?php esc_attr_e('Y', 'printed-product-customizer'); ?>" />
-                                    <button type="button" class="button fpc-design-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button>
+                                <div class="fpc-design-row fpc-template fpc-repeatable-row" data-default-title="<?php esc_attr_e('Design', 'printed-product-customizer'); ?>" style="display:none;">
+                                    <h4 class="fpc-group-toggle"><span class="fpc-group-title"><?php _e('Design', 'printed-product-customizer'); ?></span></h4>
+                                    <div class="fpc-group-fields">
+                                        <select name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][type]">
+                                            <option value="predefined">predefined</option>
+                                            <option value="custom_svg">custom_svg</option>
+                                            <option value="custom_text">custom_text</option>
+        <option value="blank">blank</option>
+                                        </select>
+                                        <input type="text" class="fpc-generate-key" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][name]" placeholder="<?php esc_attr_e('Name', 'printed-product-customizer'); ?>" />
+                                        <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][price]" placeholder="<?php esc_attr_e('Price', 'printed-product-customizer'); ?>" />
+                                        <input type="text" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][text]" placeholder="<?php esc_attr_e('Text', 'printed-product-customizer'); ?>" />
+                                        <input type="text" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][file]" placeholder="<?php esc_attr_e('SVG File', 'printed-product-customizer'); ?>" />
+                                        <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][rotation]" placeholder="<?php esc_attr_e('Rotation', 'printed-product-customizer'); ?>" />
+                                        <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][scale]" placeholder="<?php esc_attr_e('Scale', 'printed-product-customizer'); ?>" />
+                                        <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][x]" placeholder="<?php esc_attr_e('X', 'printed-product-customizer'); ?>" />
+                                        <input type="number" step="any" name="fpc_design_zones[__INDEX__][designs][__DESIGN_INDEX__][y]" placeholder="<?php esc_attr_e('Y', 'printed-product-customizer'); ?>" />
+                                        <button type="button" class="button fpc-design-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button>
+                                    </div>
                                 </div>
                             </div>
                             <p><button type="button" class="button fpc-design-add"><?php _e('Add Design', 'printed-product-customizer'); ?></button></p>
                         </div>
                     </div>
                     <p><button type="button" class="button fpc-repeatable-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button></p>
+                    </div>
                 </div>
                 <?php foreach ($zones as $index => $zone) : ?>
-                    <div class="fpc-repeatable-row">
+                    <div class="fpc-repeatable-row" data-default-title="<?php esc_attr_e('Design Zone', 'printed-product-customizer'); ?>">
+                        <h4 class="fpc-group-toggle"><span class="fpc-group-title"><?php echo esc_html($zone['label'] ?? __('Design Zone', 'printed-product-customizer')); ?></span></h4>
+                        <div class="fpc-group-fields">
                         <p class="form-field"><label><?php _e('Label', 'printed-product-customizer'); ?></label><input type="text" class="short fpc-generate-key" name="fpc_design_zones[<?php echo esc_attr($index); ?>][label]" value="<?php echo esc_attr($zone['label'] ?? ''); ?>" /></p>
                         <p class="form-field"><label><?php _e('Key', 'printed-product-customizer'); ?></label><input type="text" class="short fpc-key-field" name="fpc_design_zones[<?php echo esc_attr($index); ?>][key]" value="<?php echo esc_attr($zone['key'] ?? ''); ?>" /></p>
                         <p class="form-field"><label><?php _e('Target Body', 'printed-product-customizer'); ?></label><select name="fpc_design_zones[<?php echo esc_attr($index); ?>][body]"><option value=""><?php _e('Select body', 'printed-product-customizer'); ?></option><?php foreach ($bodies as $b) : ?><option value="<?php echo esc_attr($b); ?>" <?php selected(($zone['body'] ?? '') === $b); ?>><?php echo esc_html($b); ?></option><?php endforeach; ?></select></p>
@@ -75,40 +83,46 @@ function fpc_design_zones_product_data_panel() {
                             <label><?php _e('Designs', 'printed-product-customizer'); ?></label>
                             <div class="fpc-design-wrapper">
                                 <div class="fpc-design-container">
-                                    <div class="fpc-design-row fpc-template" style="display:none;">
-                                        <select name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][type]">
-                                            <option value="predefined">predefined</option>
-                                            <option value="custom_svg">custom_svg</option>
-                                            <option value="custom_text">custom_text</option>
-                                            <option value="blank">blank</option>
-                                        </select>
-                                        <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][name]" placeholder="<?php esc_attr_e('Name', 'printed-product-customizer'); ?>" />
-                                        <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][price]" placeholder="<?php esc_attr_e('Price', 'printed-product-customizer'); ?>" />
-                                        <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][text]" placeholder="<?php esc_attr_e('Text', 'printed-product-customizer'); ?>" />
-                                        <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][file]" placeholder="<?php esc_attr_e('SVG File', 'printed-product-customizer'); ?>" />
-                                        <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][rotation]" placeholder="<?php esc_attr_e('Rotation', 'printed-product-customizer'); ?>" />
-                                        <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][scale]" placeholder="<?php esc_attr_e('Scale', 'printed-product-customizer'); ?>" />
-                                        <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][x]" placeholder="<?php esc_attr_e('X', 'printed-product-customizer'); ?>" />
-                                        <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][y]" placeholder="<?php esc_attr_e('Y', 'printed-product-customizer'); ?>" />
-                                        <button type="button" class="button fpc-design-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button>
-                                    </div>
-                                    <?php if (!empty($zone['designs'])) : foreach ($zone['designs'] as $di => $design) : ?>
-                                        <div class="fpc-design-row">
-                                            <select name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][type]">
-                                                <option value="predefined" <?php selected(($design['type'] ?? '') === 'predefined'); ?>>predefined</option>
-                                                <option value="custom_svg" <?php selected(($design['type'] ?? '') === 'custom_svg'); ?>>custom_svg</option>
-                                                <option value="custom_text" <?php selected(($design['type'] ?? '') === 'custom_text'); ?>>custom_text</option>
-                                                <option value="blank" <?php selected(($design['type'] ?? '') === 'blank'); ?>>blank</option>
-                                            </select>
-                                            <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][name]" value="<?php echo esc_attr($design['name'] ?? ''); ?>" placeholder="<?php esc_attr_e('Name', 'printed-product-customizer'); ?>" />
-                                            <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][price]" value="<?php echo esc_attr($design['price'] ?? ''); ?>" placeholder="<?php esc_attr_e('Price', 'printed-product-customizer'); ?>" />
-                                            <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][text]" value="<?php echo esc_attr($design['text'] ?? ''); ?>" placeholder="<?php esc_attr_e('Text', 'printed-product-customizer'); ?>" />
-                                            <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][file]" value="<?php echo esc_attr($design['file'] ?? ''); ?>" placeholder="<?php esc_attr_e('SVG File', 'printed-product-customizer'); ?>" />
-                                            <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][rotation]" value="<?php echo esc_attr($design['rotation'] ?? ''); ?>" placeholder="<?php esc_attr_e('Rotation', 'printed-product-customizer'); ?>" />
-                                            <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][scale]" value="<?php echo esc_attr($design['scale'] ?? ''); ?>" placeholder="<?php esc_attr_e('Scale', 'printed-product-customizer'); ?>" />
-                                            <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][x]" value="<?php echo esc_attr($design['x'] ?? ''); ?>" placeholder="<?php esc_attr_e('X', 'printed-product-customizer'); ?>" />
-                                            <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][y]" value="<?php echo esc_attr($design['y'] ?? ''); ?>" placeholder="<?php esc_attr_e('Y', 'printed-product-customizer'); ?>" />
-                                            <button type="button" class="button fpc-design-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button>
+                                  <div class="fpc-design-row fpc-template fpc-repeatable-row" data-default-title="<?php esc_attr_e('Design', 'printed-product-customizer'); ?>" style="display:none;">
+                                      <h4 class="fpc-group-toggle"><span class="fpc-group-title"><?php _e('Design', 'printed-product-customizer'); ?></span></h4>
+                                      <div class="fpc-group-fields">
+                                          <select name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][type]">
+                                              <option value="predefined">predefined</option>
+                                              <option value="custom_svg">custom_svg</option>
+                                              <option value="custom_text">custom_text</option>
+                                              <option value="blank">blank</option>
+                                          </select>
+                                          <input type="text" class="fpc-generate-key" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][name]" placeholder="<?php esc_attr_e('Name', 'printed-product-customizer'); ?>" />
+                                          <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][price]" placeholder="<?php esc_attr_e('Price', 'printed-product-customizer'); ?>" />
+                                          <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][text]" placeholder="<?php esc_attr_e('Text', 'printed-product-customizer'); ?>" />
+                                          <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][file]" placeholder="<?php esc_attr_e('SVG File', 'printed-product-customizer'); ?>" />
+                                          <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][rotation]" placeholder="<?php esc_attr_e('Rotation', 'printed-product-customizer'); ?>" />
+                                          <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][scale]" placeholder="<?php esc_attr_e('Scale', 'printed-product-customizer'); ?>" />
+                                          <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][x]" placeholder="<?php esc_attr_e('X', 'printed-product-customizer'); ?>" />
+                                          <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][__DESIGN_INDEX__][y]" placeholder="<?php esc_attr_e('Y', 'printed-product-customizer'); ?>" />
+                                          <button type="button" class="button fpc-design-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button>
+                                      </div>
+                                  </div>
+                                      <?php if (!empty($zone['designs'])) : foreach ($zone['designs'] as $di => $design) : ?>
+                                        <div class="fpc-design-row fpc-repeatable-row" data-default-title="<?php esc_attr_e('Design', 'printed-product-customizer'); ?>">
+                                            <h4 class="fpc-group-toggle"><span class="fpc-group-title"><?php echo esc_html($design['name'] ?? __('Design', 'printed-product-customizer')); ?></span></h4>
+                                            <div class="fpc-group-fields">
+                                                <select name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][type]">
+                                                    <option value="predefined" <?php selected(($design['type'] ?? '') === 'predefined'); ?>>predefined</option>
+                                                    <option value="custom_svg" <?php selected(($design['type'] ?? '') === 'custom_svg'); ?>>custom_svg</option>
+                                                    <option value="custom_text" <?php selected(($design['type'] ?? '') === 'custom_text'); ?>>custom_text</option>
+                                                    <option value="blank" <?php selected(($design['type'] ?? '') === 'blank'); ?>>blank</option>
+                                                </select>
+                                                <input type="text" class="fpc-generate-key" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][name]" value="<?php echo esc_attr($design['name'] ?? ''); ?>" placeholder="<?php esc_attr_e('Name', 'printed-product-customizer'); ?>" />
+                                                <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][price]" value="<?php echo esc_attr($design['price'] ?? ''); ?>" placeholder="<?php esc_attr_e('Price', 'printed-product-customizer'); ?>" />
+                                                <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][text]" value="<?php echo esc_attr($design['text'] ?? ''); ?>" placeholder="<?php esc_attr_e('Text', 'printed-product-customizer'); ?>" />
+                                                <input type="text" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][file]" value="<?php echo esc_attr($design['file'] ?? ''); ?>" placeholder="<?php esc_attr_e('SVG File', 'printed-product-customizer'); ?>" />
+                                                <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][rotation]" value="<?php echo esc_attr($design['rotation'] ?? ''); ?>" placeholder="<?php esc_attr_e('Rotation', 'printed-product-customizer'); ?>" />
+                                                <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][scale]" value="<?php echo esc_attr($design['scale'] ?? ''); ?>" placeholder="<?php esc_attr_e('Scale', 'printed-product-customizer'); ?>" />
+                                                <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][x]" value="<?php echo esc_attr($design['x'] ?? ''); ?>" placeholder="<?php esc_attr_e('X', 'printed-product-customizer'); ?>" />
+                                                <input type="number" step="any" name="fpc_design_zones[<?php echo esc_attr($index); ?>][designs][<?php echo esc_attr($di); ?>][y]" value="<?php echo esc_attr($design['y'] ?? ''); ?>" placeholder="<?php esc_attr_e('Y', 'printed-product-customizer'); ?>" />
+                                                <button type="button" class="button fpc-design-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button>
+                                            </div>
                                         </div>
                                     <?php endforeach; endif; ?>
                                 </div>
@@ -116,6 +130,7 @@ function fpc_design_zones_product_data_panel() {
                             </div>
                         </div>
                         <p><button type="button" class="button fpc-repeatable-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button></p>
+                        </div>
                     </div>
                 <?php endforeach; ?>
             </div>

--- a/admin/product-tab-subgroups.php
+++ b/admin/product-tab-subgroups.php
@@ -34,53 +34,59 @@ function fpc_subgroups_product_data_panel() {
     <div id="fpc_subgroups_panel" class="panel woocommerce_options_panel hidden">
         <div class="fpc-repeatable-wrapper">
             <div class="fpc-repeatable-container">
-                <div class="fpc-repeatable-row fpc-template" style="display:none;">
-                    <p class="form-field">
-                        <label><?php _e('Label', 'printed-product-customizer'); ?></label>
-                        <input type="text" class="short fpc-generate-key" name="fpc_subgroups[__INDEX__][label]" />
-                    </p>
-                    <p class="form-field">
-                        <label><?php _e('Subgroup Key', 'printed-product-customizer'); ?></label>
-                        <input type="text" class="short fpc-key-field" name="fpc_subgroups[__INDEX__][key]" />
-                    </p>
-                    <p class="form-field">
-                        <label><?php _e('Allowed Filament Groups', 'printed-product-customizer'); ?></label>
-                        <input type="text" class="fpc-tag-input" data-options="<?php echo $filament_keys_json; ?>" name="fpc_subgroups[__INDEX__][allowed]" />
-                    </p>
-                    <p class="form-field">
-                        <label><?php _e('Allow Additional Groups', 'printed-product-customizer'); ?></label>
-                        <input type="checkbox" name="fpc_subgroups[__INDEX__][allow_additional]" value="1" />
-                    </p>
-                    <p class="form-field">
-                        <label><?php _e('Base Grams', 'printed-product-customizer'); ?></label>
-                        <input type="number" step="any" class="short" name="fpc_subgroups[__INDEX__][base_grams]" />
-                    </p>
-                    <p><button type="button" class="button fpc-repeatable-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button></p>
-                </div>
-                <?php foreach ($subgroups as $index => $sg) : ?>
-                    <div class="fpc-repeatable-row">
+                <div class="fpc-repeatable-row fpc-template" data-default-title="<?php esc_attr_e('Subgroup', 'printed-product-customizer'); ?>" style="display:none;">
+                    <h4 class="fpc-group-toggle"><span class="fpc-group-title"><?php _e('Subgroup', 'printed-product-customizer'); ?></span></h4>
+                    <div class="fpc-group-fields">
                         <p class="form-field">
                             <label><?php _e('Label', 'printed-product-customizer'); ?></label>
-                            <input type="text" class="short fpc-generate-key" name="fpc_subgroups[<?php echo esc_attr($index); ?>][label]" value="<?php echo esc_attr($sg['label'] ?? ''); ?>" />
+                            <input type="text" class="short fpc-generate-key" name="fpc_subgroups[__INDEX__][label]" />
                         </p>
                         <p class="form-field">
                             <label><?php _e('Subgroup Key', 'printed-product-customizer'); ?></label>
-                            <input type="text" class="short fpc-key-field" name="fpc_subgroups[<?php echo esc_attr($index); ?>][key]" value="<?php echo esc_attr($sg['key'] ?? ''); ?>" />
+                            <input type="text" class="short fpc-key-field" name="fpc_subgroups[__INDEX__][key]" />
                         </p>
                         <p class="form-field">
                             <label><?php _e('Allowed Filament Groups', 'printed-product-customizer'); ?></label>
-                            <?php $allowed = isset($sg['allowed']) && is_array($sg['allowed']) ? implode(', ', $sg['allowed']) : ''; ?>
-                            <input type="text" class="fpc-tag-input" data-options="<?php echo $filament_keys_json; ?>" name="fpc_subgroups[<?php echo esc_attr($index); ?>][allowed]" value="<?php echo esc_attr($allowed); ?>" />
+                            <input type="text" class="fpc-tag-input" data-options="<?php echo $filament_keys_json; ?>" name="fpc_subgroups[__INDEX__][allowed]" />
                         </p>
                         <p class="form-field">
                             <label><?php _e('Allow Additional Groups', 'printed-product-customizer'); ?></label>
-                            <input type="checkbox" name="fpc_subgroups[<?php echo esc_attr($index); ?>][allow_additional]" value="1" <?php checked(!empty($sg['allow_additional'])); ?> />
+                            <input type="checkbox" name="fpc_subgroups[__INDEX__][allow_additional]" value="1" />
                         </p>
                         <p class="form-field">
                             <label><?php _e('Base Grams', 'printed-product-customizer'); ?></label>
-                            <input type="number" step="any" class="short" name="fpc_subgroups[<?php echo esc_attr($index); ?>][base_grams]" value="<?php echo esc_attr($sg['base_grams'] ?? ''); ?>" />
+                            <input type="number" step="any" class="short" name="fpc_subgroups[__INDEX__][base_grams]" />
                         </p>
                         <p><button type="button" class="button fpc-repeatable-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button></p>
+                    </div>
+                </div>
+                <?php foreach ($subgroups as $index => $sg) : ?>
+                    <div class="fpc-repeatable-row" data-default-title="<?php esc_attr_e('Subgroup', 'printed-product-customizer'); ?>">
+                        <h4 class="fpc-group-toggle"><span class="fpc-group-title"><?php echo esc_html($sg['label'] ?? __('Subgroup', 'printed-product-customizer')); ?></span></h4>
+                        <div class="fpc-group-fields">
+                            <p class="form-field">
+                                <label><?php _e('Label', 'printed-product-customizer'); ?></label>
+                                <input type="text" class="short fpc-generate-key" name="fpc_subgroups[<?php echo esc_attr($index); ?>][label]" value="<?php echo esc_attr($sg['label'] ?? ''); ?>" />
+                            </p>
+                            <p class="form-field">
+                                <label><?php _e('Subgroup Key', 'printed-product-customizer'); ?></label>
+                                <input type="text" class="short fpc-key-field" name="fpc_subgroups[<?php echo esc_attr($index); ?>][key]" value="<?php echo esc_attr($sg['key'] ?? ''); ?>" />
+                            </p>
+                            <p class="form-field">
+                                <label><?php _e('Allowed Filament Groups', 'printed-product-customizer'); ?></label>
+                                <?php $allowed = isset($sg['allowed']) && is_array($sg['allowed']) ? implode(', ', $sg['allowed']) : ''; ?>
+                                <input type="text" class="fpc-tag-input" data-options="<?php echo $filament_keys_json; ?>" name="fpc_subgroups[<?php echo esc_attr($index); ?>][allowed]" value="<?php echo esc_attr($allowed); ?>" />
+                            </p>
+                            <p class="form-field">
+                                <label><?php _e('Allow Additional Groups', 'printed-product-customizer'); ?></label>
+                                <input type="checkbox" name="fpc_subgroups[<?php echo esc_attr($index); ?>][allow_additional]" value="1" <?php checked(!empty($sg['allow_additional'])); ?> />
+                            </p>
+                            <p class="form-field">
+                                <label><?php _e('Base Grams', 'printed-product-customizer'); ?></label>
+                                <input type="number" step="any" class="short" name="fpc_subgroups[<?php echo esc_attr($index); ?>][base_grams]" value="<?php echo esc_attr($sg['base_grams'] ?? ''); ?>" />
+                            </p>
+                            <p><button type="button" class="button fpc-repeatable-remove"><?php _e('Remove', 'printed-product-customizer'); ?></button></p>
+                        </div>
                     </div>
                 <?php endforeach; ?>
             </div>


### PR DESCRIPTION
## Summary
- Wrap subgroup rows in collapsible divs
- Wrap design zone and design rows in collapsible divs
- Auto-hide new group fields when rows are added

## Testing
- `php -l admin/product-tab-subgroups.php`
- `php -l admin/product-tab-design-zones.php`
- `node --check admin/assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6895167309808332b2b2b4d424555b52