### PR TITLE
Improve group field toggling and styling

### DIFF
--- a/admin/assets/admin.css
+++ b/admin/assets/admin.css
@@ -1,6 +1,6 @@
 .fpc-repeatable-row {
     border: 1px solid #ccc;
-    margin: 10px 0;
+    margin: 10px;
     padding: 10px;
 }
 

--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -167,6 +167,7 @@ jQuery(function($){
             template.find('.fpc-default-filament').val('psm-m-bk-petg');
         }
         $container.append(template);
+        template.find('.fpc-group-fields').hide();
         updateFilamentOptions(template);
         updateGroupTitle(template);
         toggleExemptFilaments(template);
@@ -229,7 +230,7 @@ jQuery(function($){
 
     $(document).on('click', '.fpc-group-toggle', function(e){
         e.preventDefault();
-        $(this).next('.fpc-group-fields').slideToggle();
+        $(this).closest('.fpc-repeatable-row').find('.fpc-group-fields').first().slideToggle();
     });
 
     initAdditionalGroupRules(window.fpcAdditionalGroupRules || {});


### PR DESCRIPTION
## Summary
- Add 10px horizontal margin to repeatable rows
- Fix show/hide toggle for group fields and hide additional group fields by default
- Initialize additional group rules row with same styling and behavior

## Testing
- `node --check admin/assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6895206ad478833281335cb554ba6daf